### PR TITLE
Modify the setter method of `globalAlpha` property to follow the specification 'HTML Living Standard'

### DIFF
--- a/canvas2pdf.js
+++ b/canvas2pdf.js
@@ -151,7 +151,7 @@
 
     Object.defineProperty(this, 'globalAlpha', {
       get: function () { return _this.doc.opacity(); },
-      set: function (value) { _this.doc.opacity(value); },
+      set: function (value) { (value >= 0.0 && value <= 1.0) && _this.doc.opacity(value); },
     });
 
     Object.defineProperty(this, 'font', {


### PR DESCRIPTION
### Description
Thank u for creating such a nice wrapper library!
When I was using this library with another third-party library which render graphics via `CanvasRenderingContext2D`, I noticed something strange with `globalAlpha` set to NaN.

According the link below, Values outside of the range between 0.0 and 1.0, including Infinity and NaN, will not be set, and globalAlpha will retain its previous value.
So, I wrote a patch to follow the specification 'HTML Living Standard'.

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha

I would appreciate if u review my PR and merge it.
Thank u, and best regards.